### PR TITLE
如果maidata.txt中存在`&wholebpm=`字段，则优先使用其作为歌曲的bpm。

### DIFF
--- a/MaiChartManager/Controllers/Charts/ImportChartController.cs
+++ b/MaiChartManager/Controllers/Charts/ImportChartController.cs
@@ -532,6 +532,9 @@ public partial class ImportChartController(StaticSettings settings, ILogger<Stat
         music.AddVersionId = addVersionId;
         music.GenreId = genreId;
         music.Version = version;
+        float wholebpm;
+        if (float.TryParse(maiData.GetValueOrDefault("wholebpm"), out wholebpm))
+            music.Bpm = wholebpm;
         music.Save();
         music.Refresh();
         return new ImportChartResult(errors, false);


### PR DESCRIPTION
现在的逻辑是会取出最后一张谱面的开头的bpm，作为XML中的`<bpm>`的值。
https://github.com/MuNET-OSS/MaiChartManager/blob/2dc514e2178ff3fda5df1df01c1ce8866c446883/MaiChartManager/Controllers/Charts/ImportChartController.cs#L406-L407
但是`&wholebpm=`作为一个广泛存在的字段（从astrodx上下到的官谱转谱都是有这个字段的，也有不少自制谱谱师会用这个字段声明自己歌曲的显示bpm），因此如果这个字段存在的话，最好优先使用这个字段的值。如果不存在再fallback回原来的策略。