### PR TITLE
将MaiLib的报错返回给前端，方便用户查谱面中的错

### DIFF
--- a/MaiChartManager/Controllers/Charts/ImportChartController.cs
+++ b/MaiChartManager/Controllers/Charts/ImportChartController.cs
@@ -130,6 +130,8 @@ public partial class ImportChartController(StaticSettings settings, ILogger<Stat
         }
         catch (Exception e)
         {
+            errors.Add(new ImportChartMessage($"MaiLib 解析谱面难度 {level} 时报错：\n{MaiLibErrMsgRegex().Replace(e.Message, "")}\n" +
+                                              $"这往往是谱面中的语句不够规范导致的，您可尝试根据报错对谱面进行修复。", MessageLevel.Warning));
             logger.LogWarning(e, "无法在手动修正错误后解析谱面");
         }
 
@@ -339,6 +341,9 @@ public partial class ImportChartController(StaticSettings settings, ILogger<Stat
      */
     [GeneratedRegex(@"(?<!\[[^\]]*|\{[^\}]*)#.*$", RegexOptions.Multiline)]
     private static partial Regex SimaiCommentRegex2();
+
+    [GeneratedRegex(@"Original Stack.*", RegexOptions.Singleline)]
+    private static partial Regex MaiLibErrMsgRegex();
 
     [HttpPost]
     // 创建完 Music 后调用

--- a/MaiChartManager/Controllers/Charts/ImportChartController.cs
+++ b/MaiChartManager/Controllers/Charts/ImportChartController.cs
@@ -333,7 +333,11 @@ public partial class ImportChartController(StaticSettings settings, ILogger<Stat
     [GeneratedRegex(@"\|\|.*$", RegexOptions.Multiline)]
     private static partial Regex SimaiCommentRegex();
 
-    [GeneratedRegex(@"#.*$", RegexOptions.Multiline)]
+    /*
+     * 根据[simai文档](https://w.atwiki.jp/simai/pages/1002.html)，井号如果出现在[]或{}内是合法语法，并非注释。
+     * 因此在尝试匹配注释时，应该排除掉#前面有未闭合的[或{的情况。
+     */
+    [GeneratedRegex(@"(?<!\[[^\]]*|\{[^\}]*)#.*$", RegexOptions.Multiline)]
     private static partial Regex SimaiCommentRegex2();
 
     [HttpPost]


### PR DESCRIPTION
近一段时间我已经遇到过两次了：别人的谱面导不进去/用SimaiSharp导进去有很大问题，发现是他们的simai写的不够规范。

Majdataplay是一个鲁棒性极强的parser（笑），写成什么样它都能解析，然而MaiLib并不是（我觉得这样挺好的，作为库还是应该严格按Spec实现，而不是兼容很多莫名其妙的写法，这样会让用户养成坏习惯的x）

综上，本PR将MaiLib解析报错直接返回给前端，从而使用户有机会根据报错修复他们谱面中的不合规范之处；之前的版本只是提示解析失败却不给出任何有用的信息，确实会让用户比较困惑。

顺便， cc06b0d 还修了一个bug：井号出现在大括号或中括号中是[simai文档](https://w.atwiki.jp/simai/pages/1002.html)允许的语法，不应该作为注释给移除掉。